### PR TITLE
Fix deleting of extra rectangles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,8 @@
     "xstring": "cpp",
     "xtr1common": "cpp",
     "xutility": "cpp",
-    "string": "cpp"
+    "string": "cpp",
+    "algorithm": "cpp"
   },
   "C_Cpp.errorSquiggles": "disabled"
 }

--- a/logic/headers/figures.hpp
+++ b/logic/headers/figures.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "math_staff.hpp"
+#include <iostream>
 #include <cmath> // For std::sqrt
 
 class Point
@@ -12,6 +13,7 @@ public:
     Point(const Point &el) : x{el.x}, y{el.y} {}
     Point(double x, double y) : x(x), y(y) {}
     friend bool operator==(const Point &p1, const Point &p2);
+    friend std::ostream &operator<<(std::ostream &os, const Point &p); // mainly for debug purposes
     ~Point() {}
 };
 
@@ -41,6 +43,7 @@ public:
     bool isValid() const;
     std::vector<Edge> get_edges() const;
     bool contains_point(const Point &p) const;
+    friend std::ostream &operator<<(std::ostream &os, const Triangle &p); // mainly for debug purposes
 };
 
 struct Circle

--- a/logic/headers/my_functions.hpp
+++ b/logic/headers/my_functions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <algorithm>
 #include "figures.hpp"
 
 Triangle initial_super_triangle(const std::vector<Point> &points);

--- a/logic/src/figures.cpp
+++ b/logic/src/figures.cpp
@@ -81,10 +81,6 @@ bool Triangle::contains_point(const Point &p) const
     {
         return true;
     }
-    cout << "=====================" << endl;
-    cout << "a: " << a << " b: " << b << " c : " << c << endl;
-    cout << "Point that is checked: " << p << endl;
-    cout << "=====================" << endl;
     return false;
 }
 

--- a/logic/src/figures.cpp
+++ b/logic/src/figures.cpp
@@ -1,4 +1,5 @@
 #include "../headers/figures.hpp"
+#include <ostream>
 
 using std::cout;
 using std::endl;
@@ -16,6 +17,19 @@ bool operator==(const Point &p1, const Point &p2)
 bool operator==(const Edge &e1, const Edge &e2)
 {
     return (e1.a == e2.a && e1.b == e2.b) || (e1.a == e2.b && e1.b == e2.a);
+}
+
+std::ostream &operator<<(std::ostream &os, const Point &p)
+{
+    os << "(x: " << p.x << "; " << p.y << ")";
+    return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const Triangle &p)
+{
+    os << "Triangle\n"
+       << "a: " << p.a << "b: " << p.b << " c: " << p.c << endl;
+    return os;
 }
 
 bool check_if_point_inside_circle(const Point &p, const Circle &c)
@@ -67,6 +81,10 @@ bool Triangle::contains_point(const Point &p) const
     {
         return true;
     }
+    cout << "=====================" << endl;
+    cout << "a: " << a << " b: " << b << " c : " << c << endl;
+    cout << "Point that is checked: " << p << endl;
+    cout << "=====================" << endl;
     return false;
 }
 
@@ -105,7 +123,6 @@ Circle Circle::calculate_circumscribed_circle(const Triangle &triangle)
     }
     else
     {
-        cout << "k_m1: " << k_m1 << " k_m2: " << k_m2 << endl;
         std::vector<std::vector<double>> matrix_A = {
             {-k_m1, 1.0},
             {-k_m2, 1.0}};

--- a/logic/src/my_functions.cpp
+++ b/logic/src/my_functions.cpp
@@ -1,5 +1,8 @@
 #include "../headers/my_functions.hpp"
 
+using std::cout;
+using std::endl;
+
 Triangle initial_super_triangle(const std::vector<Point> &points)
 {
     Point top, left, right, bottom;
@@ -69,9 +72,23 @@ bool check_edge(const std::vector<Triangle> &all_triangels,
 std::vector<Triangle> clean_triangulation_res(const std::vector<Triangle> &triangulation_res, const std::vector<int> &remove_indexes)
 {
     std::vector<Triangle> result = triangulation_res;
-    for (int index = remove_indexes.size() - 1; index > -1; index--)
+    int index = 0;
+    for (const auto &t : result)
     {
-        result.erase(result.begin() + index);
+        cout << "index: " << index << endl;
+        cout << t << endl;
+        index++;
+    }
+
+    // Make a copy and sort in descending order
+    std::vector<int> sorted_remove_indexes = remove_indexes;
+    std::sort(sorted_remove_indexes.rbegin(), sorted_remove_indexes.rend());
+
+    for (int idx : sorted_remove_indexes)
+    {
+        cout << "Delete with index: " << idx << endl;
+        result.erase(result.begin() + idx);
+        cout << "Size of result now: " << result.size();
     }
     return result;
 }
@@ -128,6 +145,7 @@ std::vector<Triangle> triangulation(const std::vector<Point> &points)
             bad_triangles_indexes.push_back(index);
         }
     }
+    cout << "Bad triangles size: " << bad_triangles_indexes.size() << endl;
 
     triangulation_res = clean_triangulation_res(triangulation_full, bad_triangles_indexes);
     return triangulation_res;

--- a/logic/src/my_functions.cpp
+++ b/logic/src/my_functions.cpp
@@ -72,23 +72,13 @@ bool check_edge(const std::vector<Triangle> &all_triangels,
 std::vector<Triangle> clean_triangulation_res(const std::vector<Triangle> &triangulation_res, const std::vector<int> &remove_indexes)
 {
     std::vector<Triangle> result = triangulation_res;
-    int index = 0;
-    for (const auto &t : result)
-    {
-        cout << "index: " << index << endl;
-        cout << t << endl;
-        index++;
-    }
 
-    // Make a copy and sort in descending order
     std::vector<int> sorted_remove_indexes = remove_indexes;
     std::sort(sorted_remove_indexes.rbegin(), sorted_remove_indexes.rend());
 
     for (int idx : sorted_remove_indexes)
     {
-        cout << "Delete with index: " << idx << endl;
         result.erase(result.begin() + idx);
-        cout << "Size of result now: " << result.size();
     }
     return result;
 }
@@ -145,7 +135,6 @@ std::vector<Triangle> triangulation(const std::vector<Point> &points)
             bad_triangles_indexes.push_back(index);
         }
     }
-    cout << "Bad triangles size: " << bad_triangles_indexes.size() << endl;
 
     triangulation_res = clean_triangulation_res(triangulation_full, bad_triangles_indexes);
     return triangulation_res;


### PR DESCRIPTION
# Why changes

So far we had one extra triangle after `clearing_extra_traingles`

# Changes

- Fix the algorithm 
- Add output logic for point and triangle

# Result

**Was:** 
<img width="350" height="300" alt="image" src="https://github.com/user-attachments/assets/0fcb657c-db17-46ea-9c87-6629415affa7" />

**Now:**
<img width="350" height="300" alt="image" src="https://github.com/user-attachments/assets/bf99e02e-4397-485c-a94f-2f44aab5279a" />
